### PR TITLE
노란색 스탬프 능력 사용 관련 버그 수정

### DIFF
--- a/Assets/JaeseongHan/Common/Prefabs/YellowChecker.prefab
+++ b/Assets/JaeseongHan/Common/Prefabs/YellowChecker.prefab
@@ -1,0 +1,82 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7061928288266999929
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7061928288266999934}
+  - component: {fileID: 7061928288266999935}
+  - component: {fileID: 7061928288266999933}
+  - component: {fileID: 5455960185396639490}
+  m_Layer: 8
+  m_Name: YellowChecker
+  m_TagString: Untagged
+  m_Icon: {fileID: 2974397684917235467, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7061928288266999934
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7061928288266999929}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5.911, y: 7.1, z: -5.275}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &7061928288266999935
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7061928288266999929}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.5, y: 0.5, z: 0.5}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!54 &7061928288266999933
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7061928288266999929}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0
+--- !u!114 &5455960185396639490
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7061928288266999929}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7dc5c024bd6351942b68a214c4837155, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  canMove: 0
+  layerMask:
+    serializedVersion: 2
+    m_Bits: 512
+  distance: 0

--- a/Assets/JaeseongHan/Common/Prefabs/YellowChecker.prefab.meta
+++ b/Assets/JaeseongHan/Common/Prefabs/YellowChecker.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: dd10bb2e6d0d0204ea88271499c23bdc
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JaeseongHan/Common/Scripts/YellowChecker.cs
+++ b/Assets/JaeseongHan/Common/Scripts/YellowChecker.cs
@@ -1,0 +1,46 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+///  노란색 스탬프 확인 클래스 
+/// </summary>
+public class YellowChecker : MonoBehaviour
+{
+    [SerializeField] bool canMove;          // 돌진 가능 여부
+    [SerializeField] LayerMask layerMask;   // 확인할 레이어 마스크
+
+    [SerializeField] float distance;        // 레이캐스트 거리
+
+    /// <summary>
+    /// 돌진 가능 여부를 가져오는 프로퍼티
+    /// </summary>
+    public bool CanMove { get { return canMove; } private set { } }
+
+    public void CheckRay()
+    {
+        RaycastHit hit;
+
+        // Ray를 checker의 아래 방향으로 발사하고
+        Ray ray = new Ray(transform.position, Vector3.down);
+        Physics.Raycast(ray, out hit, distance, layerMask);
+
+        // 해당 Ray에 걸린 오브젝트(Map)가 있으면 갈 수 있다
+        canMove = (hit.collider) ? true : false;
+
+        // 그런데 Map인데 ClearStampTile(리셋, 지우기) 타일이면?
+        // 바로 앞에 멈추게 (못가게 해야한다)
+        if (canMove
+            && hit.collider.gameObject.GetComponent<ClearStampTile>() is not null
+            && hit.collider.gameObject.GetComponent<ClearStampTile>().enabled.Equals(true))
+        {
+            canMove = false;
+        }
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        // Todo: 레이어 충돌을 Map만 -> 코드 간략화
+        canMove = false;
+    }
+}

--- a/Assets/JaeseongHan/Common/Scripts/YellowChecker.cs.meta
+++ b/Assets/JaeseongHan/Common/Scripts/YellowChecker.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7dc5c024bd6351942b68a214c4837155
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JaeseongHan/HJS_Stage1 temp.unity.meta
+++ b/Assets/JaeseongHan/HJS_Stage1 temp.unity.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: b466e66d29eee1b4caefeb0082069bd2
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JaeseongHan/Prefabs/YellowChecker2.prefab
+++ b/Assets/JaeseongHan/Prefabs/YellowChecker2.prefab
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4096096801578446203
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4096096801578446204}
+  - component: {fileID: 4096096801578446205}
+  - component: {fileID: 4096096801578446202}
+  - component: {fileID: 4096096801578446207}
+  m_Layer: 8
+  m_Name: YellowChecker2
+  m_TagString: Untagged
+  m_Icon: {fileID: 2974397684917235467, guid: 0000000000000000d000000000000000, type: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4096096801578446204
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4096096801578446203}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 5.911, y: 7.1, z: -5.275}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 1
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!65 &4096096801578446205
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4096096801578446203}
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_Enabled: 1
+  serializedVersion: 2
+  m_Size: {x: 0.5, y: 0.5, z: 0.5}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &4096096801578446202
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4096096801578446203}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b90aa1a914e7e60458fc8ebb7889d80e, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  canMove: 0
+  layerMask:
+    serializedVersion: 2
+    m_Bits: 512
+  target: {fileID: 0}
+  distance: 1
+--- !u!54 &4096096801578446207
+Rigidbody:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4096096801578446203}
+  serializedVersion: 2
+  m_Mass: 1
+  m_Drag: 0
+  m_AngularDrag: 0.05
+  m_UseGravity: 0
+  m_IsKinematic: 1
+  m_Interpolate: 0
+  m_Constraints: 0
+  m_CollisionDetection: 0

--- a/Assets/JaeseongHan/Prefabs/YellowChecker2.prefab.meta
+++ b/Assets/JaeseongHan/Prefabs/YellowChecker2.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 62d5fa3db5d21a44d9c76c73dc41d16c
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/JaeseongHan/Scripts/CheckCollider2.cs
+++ b/Assets/JaeseongHan/Scripts/CheckCollider2.cs
@@ -1,70 +1,70 @@
 //using System.Collections;
 //using System.Collections.Generic;
 //using UnityEditor.Experimental.GraphView;
-//using UnityEngine;
-//using UnityEngine.Events;
-//using UnityEngine.Rendering;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.Rendering;
 
-///// <summary>
-///// 콜라이더 
-///// </summary>
-//public class CheckCollider2 : MonoBehaviour
-//{
-//    [SerializeField] StampType2 type;               // 큐브에 달려있는 스탬프 확인
-//    [SerializeField] BoxCollider boxCollider;       // 콜라이더
-//<<<<<<< JongYoPark
-//=======
-//    //[SerializeField] UseStampAbility2 useStampAbility;  // 스탬프 능력을 관리하는 스크립트
-//>>>>>>> Develop
+/// <summary>
+/// 콜라이더 
+/// </summary>
+public class CheckCollider2 : MonoBehaviour
+{
+    [SerializeField] StampType2 type;               // 큐브에 달려있는 스탬프 확인
+    [SerializeField] BoxCollider boxCollider;       // 콜라이더
 
-//    private void Awake()
-//    {
-//        boxCollider = GetComponent<BoxCollider>();
-//    }
 
-//    private void Update()
-//    {
-//        // 임시로 번호키를 누르면 변경
-//        if (Input.GetKeyDown(KeyCode.Alpha1))
-//        {
-//            type.ChangeType = StampType2.StampType.None;
-//        }
-//        else if (Input.GetKeyDown(KeyCode.Alpha2))
-//        {
-//            type.ChangeType = StampType2.StampType.Red;
+    [SerializeField] UseStampAbility2 useStampAbility;  // 스탬프 능력을 관리하는 스크립트
 
-//        }
-//        else if (Input.GetKeyDown(KeyCode.Alpha3))
-//        {
-//            type.ChangeType = StampType2.StampType.Blue;
-//        }
-//        else if (Input.GetKeyDown(KeyCode.Alpha4))
-//        {
-//            type.ChangeType = StampType2.StampType.Yellow;
-//        }
-//    }
 
-//    private void OnTriggerEnter(Collider other)
-//    {
-//        StampType2 type = other.GetComponent<StampType2>();
+    private void Awake()
+    {
+        boxCollider = GetComponent<BoxCollider>();
+    }
 
-//        // type 컴포넌트가 있다 -> cube에 붙어 있는 Stemp
-//        if (type is not null)
-//        {
-//            this.type = type;
-//            useStampAbility.ChangeAbility(type.GetStampType);
-//            Debug.Log($"enter object : {other.gameObject.name}");
-//        }
-//    }
+    private void Update()
+    {
+        // 임시로 번호키를 누르면 변경
+        if (Input.GetKeyDown(KeyCode.Alpha1))
+        {
+            type.ChangeType = StampType2.StampType.None;
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha2))
+        {
+            type.ChangeType = StampType2.StampType.Red;
 
-//    private void OnTriggerExit(Collider other)
-//    {
-//        StampType2 type = other.GetComponent<StampType2>();
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha3))
+        {
+            type.ChangeType = StampType2.StampType.Blue;
+        }
+        else if (Input.GetKeyDown(KeyCode.Alpha4))
+        {
+            type.ChangeType = StampType2.StampType.Yellow;
+        }
+    }
 
-//        if (this.type.Equals(type))
-//        {
-//            this.type = null;
-//            useStampAbility.ChangeAbility(StampType2.StampType.None);
-//        }
-//    }
-//}
+    private void OnTriggerEnter(Collider other)
+    {
+        StampType2 type = other.GetComponent<StampType2>();
+
+        // type 컴포넌트가 있다 -> cube에 붙어 있는 Stemp
+        if (type is not null)
+        {
+            this.type = type;
+            useStampAbility.ChangeAbility(type.GetStampType);
+            Debug.Log($"enter object : {other.gameObject.name}");
+        }
+    }
+
+    private void OnTriggerExit(Collider other)
+    {
+        StampType2 type = other.GetComponent<StampType2>();
+
+        if (this.type.Equals(type))
+        {
+            this.type = null;
+            useStampAbility.ChangeAbility(StampType2.StampType.None);
+        }
+    }
+}

--- a/Assets/JaeseongHan/Scripts/YellowChecker2.cs
+++ b/Assets/JaeseongHan/Scripts/YellowChecker2.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+public class YellowChecker2 : MonoBehaviour
+{
+    [SerializeField] bool canMove;  // 돌진 가능 여부
+    [SerializeField] LayerMask layerMask; // 확인할 레이어 마스크
+
+    [SerializeField] GameObject target;     // 레이어 마스크로 확인한 친구
+    [SerializeField] float distance;
+
+    public bool CanMove { get { Debug.LogWarning($"{gameObject.name} - getCanMove: {canMove}"); return canMove; } private set { } }
+
+    private List<bool> bools = new List<bool>();
+
+    public void CheckRay()
+    {
+        Debug.Log($"{gameObject.name} - CheckRay");
+        bools.Add(canMove);
+
+        RaycastHit hit;
+
+        // Ray를 checker의 아래 방향으로 발사하고
+        Ray ray = new Ray(transform.position, Vector3.down);
+        Physics.Raycast(ray, out hit, distance, layerMask);
+
+        // 해당 Ray에 걸린 오브젝트(Map)가 있으면 갈 수 있다
+        canMove = (hit.collider) ? true : false;
+
+        // 그런데 Map인데 ClearStampTile(리셋, 지우기) 타일이면?
+        // 바로 앞에 멈추게 (못가게 해야한다)
+        if (canMove
+            && hit.collider.gameObject.GetComponent<ClearStampTile>() is not null
+            && hit.collider.gameObject.GetComponent<ClearStampTile>().enabled.Equals(true))
+        {
+            canMove = false;
+        }
+
+        bools.Add(canMove);
+        Debug.LogWarning($"{gameObject.name} - {bools[0]}, {bools[1]}");
+    }
+
+    private void OnTriggerEnter(Collider other)
+    {
+        // Todo: 레이어 충돌을 Map만 -> 코드 간략화
+        Debug.Log($"{gameObject.name} - triggerEnter {other.gameObject.name}");
+        canMove = false;
+    }
+}

--- a/Assets/JaeseongHan/Scripts/YellowChecker2.cs.meta
+++ b/Assets/JaeseongHan/Scripts/YellowChecker2.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b90aa1a914e7e60458fc8ebb7889d80e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
## 노란색 스탬프 능력 사용 관련 버그 수정

- 노란색 스탬프 중력 안 받게 예외처리
- 노란색 스탬프 이동 예외처리
  -  갈 수 없는 곳 가는 이동 처리
-  노란색 스탬프 능력 사용 시 리셋 타일 관련 버그 예외처리 
  -  리셋 타일 앞까지만 이동하게 변경

Related to: #45 #46 #52