### PR TITLE
노란색 스탬프 버그 수정

### DIFF
--- a/Assets/JaeseongHan/Common/Prefabs/Sensor.prefab
+++ b/Assets/JaeseongHan/Common/Prefabs/Sensor.prefab
@@ -10,7 +10,7 @@ GameObject:
   m_Component:
   - component: {fileID: 3404852352743734181}
   - component: {fileID: 3404852352743734182}
-  - component: {fileID: 3404852352743734183}
+  - component: {fileID: 7819849686321048325}
   - component: {fileID: 3404852352743734184}
   - component: {fileID: 1107464088538849317}
   - component: {fileID: -1063600980061344377}
@@ -88,7 +88,7 @@ SpriteRenderer:
   m_WasSpriteAssigned: 0
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
---- !u!65 &3404852352743734183
+--- !u!65 &7819849686321048325
 BoxCollider:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
@@ -99,8 +99,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.5, y: 0.5, z: 0.05}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 0.5, y: 0.5, z: 0.2}
+  m_Center: {x: 0, y: 0, z: -0.08}
 --- !u!54 &3404852352743734184
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/JaeseongHan/Common/Scripts/YellowChecker.cs
+++ b/Assets/JaeseongHan/Common/Scripts/YellowChecker.cs
@@ -37,18 +37,9 @@ public class YellowChecker : MonoBehaviour
         canMove = (hit.collider) ? true : false;
 
 
-        // 그런데 Map인데 ClearStampTile(리셋, 지우기) 타일이면?
-        // 바로 앞에 멈추게 (못가게 해야한다)
+        // 만약 경사로 타일이 있으면 해당 위로는 못가게
         if (canMove
-            && hit.collider.gameObject.GetComponent<ClearStampTile>() is not null
-            && hit.collider.gameObject.GetComponent<ClearStampTile>().enabled.Equals(true))
-        {
-            canMove = false;
-        }
-        else if (canMove
             && hit.collider.gameObject.name.Contains("slope")) canMove = false;
-        else if (canMove
-            && hit.collider.gameObject.GetComponent<Elevator>() is not null) canMove = false;
 
     }
 

--- a/Assets/JaeseongHan/HJS_Test_RIgidBodyScene.unity
+++ b/Assets/JaeseongHan/HJS_Test_RIgidBodyScene.unity
@@ -651,7 +651,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1520574018}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: 0.7071068, y: 0.7071068, z: 0, w: 0}
   m_LocalPosition: {x: 1.5, y: 0.5, z: -3.5}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -659,7 +659,7 @@ Transform:
   - {fileID: 2142595736}
   m_Father: {fileID: 0}
   m_RootOrder: 3
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 180, z: 90}
 --- !u!54 &1520574023
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/JaeseongHan/Scripts/TransMove2.cs
+++ b/Assets/JaeseongHan/Scripts/TransMove2.cs
@@ -14,17 +14,37 @@ public class TransMove2 : MonoBehaviour
         rigid = GetComponent<Rigidbody>();
     }
 
+    private void Start()
+    {
+        StartCoroutine(Move());
+    }
+
     private void FixedUpdate()
     {
-        foreach (Rigidbody body in bodies)
-        {
-            body.position = body.transform.position + Vector3.forward * Time.deltaTime;
-            transform.position = transform.position + Vector3.forward * Time.deltaTime;
-        }
+        //   foreach (Rigidbody body in bodies)
+        //   {
+        //       body.position = body.transform.position + Vector3.forward * Time.fixedDeltaTime;
+        //   }
+        //transform.position = transform.position + Vector3.forward * Time.deltaTime;
+        
     }
 
     private void Update()
     {
-        transform.position = transform.position + Vector3.forward * Time.deltaTime;
+      //  transform.position = transform.position + Vector3.forward * Time.deltaTime;
+    }
+
+    private IEnumerator Move()
+    {
+        while (true)
+        {
+            transform.position = transform.position + Vector3.forward * Time.deltaTime;
+            yield return null;
+            foreach (Rigidbody body in bodies)
+            {
+                body.MovePosition(body.position + Vector3.forward * Time.fixedDeltaTime);
+                //body.position = body.transform.position + Vector3.forward * Time.fixedDeltaTime;
+            }
+        }
     }
 }

--- a/Assets/KwonMinGyu/Common/CubeMove.cs
+++ b/Assets/KwonMinGyu/Common/CubeMove.cs
@@ -205,6 +205,8 @@ public class CubeMove : MonoBehaviour
         // 회전이 90도보다 적거나 많이 될 때 90도로 조정
         transform.RotateAround(point, axis, 90 - angle);
 
+        // 이동 했을 때 높이 보정
+        transform.position = new Vector3(transform.position.x , Mathf.Round(transform.position.y), transform.position.z);
 
         // CubeCheck를 큐브 위로 이동 후 CubeCheck 활성화
         _cubeChecker.RePosition(transform.position);

--- a/Assets/Stage/Prefab/Get Stamp.prefab
+++ b/Assets/Stage/Prefab/Get Stamp.prefab
@@ -99,8 +99,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.5, y: 0.5, z: 0.05}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 0.5, y: 0.5, z: 0.2}
+  m_Center: {x: 0, y: 0, z: -0.08}
 --- !u!54 &1375278939824072470
 Rigidbody:
   m_ObjectHideFlags: 0

--- a/Assets/Stage/Prefab/Set Stamp.prefab
+++ b/Assets/Stage/Prefab/Set Stamp.prefab
@@ -197,8 +197,8 @@ BoxCollider:
   m_IsTrigger: 1
   m_Enabled: 1
   serializedVersion: 2
-  m_Size: {x: 0.5, y: 0.5, z: 0.05}
-  m_Center: {x: 0, y: 0, z: 0}
+  m_Size: {x: 0.5, y: 0.5, z: 0.2}
+  m_Center: {x: 0, y: 0, z: -0.08}
 --- !u!54 &5505106263550517990
 Rigidbody:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
## 노란색 스탬프 버그 수정

- 노란색 스탬프 돌진 중 엉뚱한 면에 배치되는 버그 수정
- 물타일, 리셋타일 앞에서 능력 사용가능하게 수정

### 수정한 공용 파일
- CubeMove
- GetStamp.prefab
- SetStamp.prefab
- Sensor.prefab
- YellowMover
- YellowChekcer

Related to: #79 #89