### PR TITLE
Fix: 노란색 스탬프 공중 예외 처리

### DIFF
--- a/Assets/JaeseongHan/Common/Prefabs/YellowChecker.prefab
+++ b/Assets/JaeseongHan/Common/Prefabs/YellowChecker.prefab
@@ -79,4 +79,8 @@ MonoBehaviour:
   layerMask:
     serializedVersion: 2
     m_Bits: 65
-  distance: 1
+  distance: 0.7
+  destroyTarget: {fileID: 0}
+  destroyCubeEvent:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/JaeseongHan/Prefabs/YellowChecker2.prefab
+++ b/Assets/JaeseongHan/Prefabs/YellowChecker2.prefab
@@ -64,7 +64,7 @@ MonoBehaviour:
     serializedVersion: 2
     m_Bits: 512
   target: {fileID: 0}
-  distance: 1
+  distance: 0.7
 --- !u!54 &4096096801578446207
 Rigidbody:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
노란색 스탬프 돌진시 엘베타일 위에서 공중에 떠있는 버그 수정

Related to: #104