### PR TITLE
Fix : 레드 스탬프 버그 수정

### DIFF
--- a/Assets/KwonMinGyu/Common/RedStamp.cs
+++ b/Assets/KwonMinGyu/Common/RedStamp.cs
@@ -91,7 +91,7 @@ public class RedStamp : MonoBehaviour
         AudioManager.Instance.PlaySfx(AudioManager.Sfx.Scaffolding);
         // 바닥 생성 카운트
         useRedGround++;
-        if (useRedGround == maxRedGround) _plane.SetActive(false);
+        if (useRedGround == maxRedGround) _cubeMove.IsRolling = true;
     }
 
     private void Pool(GameObject _prefab, Transform _transform)
@@ -100,6 +100,7 @@ public class RedStamp : MonoBehaviour
         {
             if (item.activeSelf) continue;
             item.transform.position = _transform.position;
+            item.transform.GetComponent<MeshRenderer>().enabled = true;
             item.SetActive(true);
             return;
         }


### PR DESCRIPTION
레드 스탬프가 바닥이 있을 때 계속 사용할 수 있는 버그를 수정
카메라에 의해 메쉬 렌더러가 비활성화된 후 원복 되지 않는 버그를 수정 